### PR TITLE
fix: allow empty test bodies

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ function wrapDescribeInZone(describeBody) {
 // can retroactively install different zones.
 const testProxyZone = ambientZone.fork(new ProxyZoneSpec());
 function wrapTestInZone(testBody) {
+  if (testBody === undefined) {
+    return;
+  }
   return testBody.length === 0
     ? () => testProxyZone.run(testBody, null)
     : done => testProxyZone.run(testBody, null, [done]);


### PR DESCRIPTION
In jest/jasmine, if you don't provide a test body for an `it` statement, it should just mark the test as skipped. This is a very simple way to write out a bunch of scenarios and then incrementally add the test cases for each. 

Example:
```
it('should return a string');
```

When you try and run a test suite using the above syntax you get the following error:
```
TypeError: Cannot read property 'length' of undefined
      at wrapTestInZone (node_modules/jest-zone-patch/index.js:46:18)
```
This PR should fix this problem.