### PR TITLE
feat: support jest-each method

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,11 +53,11 @@ function wrapTestInZone(testBody) {
 
 const bindDescribe = (originalJestFn) => function () {
   const eachArguments = arguments;
-  return function (description, specDefinitions) {
-    return originalJestFn.apply(this, eachArguments).call(
+  return function (description, specDefinitions, timeout) {
+    arguments[1] = wrapDescribeInZone(specDefinitions)
+    return originalJestFn.apply(this, eachArguments).apply(
       this,
-      description,
-      wrapDescribeInZone(specDefinitions)
+      arguments
     )
   }
 };
@@ -65,10 +65,10 @@ const bindDescribe = (originalJestFn) => function () {
 ['xdescribe', 'fdescribe', 'describe'].forEach(methodName => {
   const originaljestFn = env[methodName];
   env[methodName] = function(description, specDefinitions, timeout) {
-    return originaljestFn.call(
+    arguments[1] = wrapDescribeInZone(specDefinitions)
+    return originaljestFn.apply(
       this,
-      description,
-      wrapDescribeInZone(specDefinitions)
+      arguments
     );
   };
   env[methodName].each = bindDescribe(originaljestFn.each);

--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ const bindDescribe = (originalJestFn) => function () {
       wrapDescribeInZone(specDefinitions)
     );
   };
+  env[methodName].each = bindDescribe(originaljestFn.each);
   if (methodName === 'describe') {
-    env[methodName].each = bindDescribe(originaljestFn.each);
     env[methodName].only = env['fdescribe'];
     env[methodName].skip = env['xdescribe'];
     env[methodName].only.each = bindDescribe(originaljestFn.only.each);

--- a/index.js
+++ b/index.js
@@ -51,6 +51,17 @@ function wrapTestInZone(testBody) {
     : done => testProxyZone.run(testBody, null, [done]);
 }
 
+const bindDescribe = (originalJestFn) => function () {
+  const eachArguments = arguments;
+  return function (description, specDefinitions) {
+    return originalJestFn.apply(this, eachArguments).call(
+      this,
+      description,
+      wrapDescribeInZone(specDefinitions)
+    )
+  }
+};
+
 ['xdescribe', 'fdescribe', 'describe'].forEach(methodName => {
   const originaljestFn = env[methodName];
   env[methodName] = function(description, specDefinitions) {
@@ -61,8 +72,11 @@ function wrapTestInZone(testBody) {
     );
   };
   if (methodName === 'describe') {
+    env[methodName].each = bindDescribe(originaljestFn.each);
     env[methodName].only = env['fdescribe'];
     env[methodName].skip = env['xdescribe'];
+    env[methodName].only.each = bindDescribe(originaljestFn.only.each);
+    env[methodName].skip.each = bindDescribe(originaljestFn.skip.each);
   }
 });
 
@@ -72,9 +86,14 @@ function wrapTestInZone(testBody) {
     arguments[1] = wrapTestInZone(specDefinitions);
     return originaljestFn.apply(this, arguments);
   };
+  // The revised method will be populated to the final each method, so we only declare the method that in the new globals
+  env[methodName].each = originaljestFn.each;
   if (methodName === 'test' || methodName === 'it') {
     env[methodName].only = env['fit'];
+    env[methodName].only.each = originaljestFn.only.each;
+
     env[methodName].skip = env['xit'];
+    env[methodName].skip.each = originaljestFn.skip.each;
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ const bindDescribe = (originalJestFn) => function () {
   }
 });
 
-['xit', 'fit', 'test', 'it'].forEach(methodName => {
+['xit', 'fit', 'xtest', 'test', 'it'].forEach(methodName => {
   const originaljestFn = env[methodName];
   env[methodName] = function(description, specDefinitions, timeout) {
     arguments[1] = wrapTestInZone(specDefinitions);

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ const bindDescribe = (originalJestFn) => function () {
 
 ['xdescribe', 'fdescribe', 'describe'].forEach(methodName => {
   const originaljestFn = env[methodName];
-  env[methodName] = function(description, specDefinitions) {
+  env[methodName] = function(description, specDefinitions, timeout) {
     return originaljestFn.call(
       this,
       description,


### PR DESCRIPTION
Closes #7 

While I am inspired from #7, after some experiment I find out the original approach is error-prone and far from workable. So I draft a new branch to get it done.

[Here](https://gist.github.com/JLHwung/c404a8f4f9e9abef48db3395d48207fe) is my test snippet.

@thymikee It would be great if you can inspect into the approach and give me some suggestion. Thanks.

This branch is generally working now and here is just a todolist to tinker the PR to a perfection level in my own perspective.

- [x] Add support for `xtest`
- [ ] Figure out why the modified `describe` does not populate to `descirbe.each`, that is, try to eliminate `bindDescribe`.