### PR TITLE
fix: improper bindings of arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const ambientZone = Zone.current;
 // inside of a `describe` but outside of a `beforeEach` or `it`.
 const syncZone = ambientZone.fork(new SyncTestZoneSpec('jest.describe'));
 function wrapDescribeInZone(describeBody) {
-  return () => syncZone.run(describeBody, null, arguments);
+  return function () { return syncZone.run(describeBody, null, arguments); }
 }
 
 // Create a proxy zone in which to run `test` blocks so that the tests function


### PR DESCRIPTION
The arrow function has no bindings of `arguments` object. I doubt if it has ever been working properly.

Fixed https://github.com/thymikee/jest-preset-angular/issues/169#issuecomment-445731951

I suggest we add some integration test (is that why the version is dangerously 0.0.x?) to prove the snippet works as intended.